### PR TITLE
[Bugfix] Update Mark Comment Spacing

### DIFF
--- a/Moulinette.podspec
+++ b/Moulinette.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Moulinette'
-  s.version          = '0.1.3'
+  s.version          = '0.1.4'
   s.summary          = 'An internal Xcode audit tool.'
 
   s.description      = <<-DESC

--- a/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
@@ -64,7 +64,6 @@ final class ConstantsMarkSectionSwiftRule: CorrectableSwiftRule {
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
             let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
             let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
-            print(fileComponents[lineNumber - 1])
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
@@ -64,6 +64,7 @@ final class ConstantsMarkSectionSwiftRule: CorrectableSwiftRule {
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
             let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
             let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+            
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/ConstantsMarkSectionSwiftRule.swift
@@ -62,7 +62,9 @@ final class ConstantsMarkSectionSwiftRule: CorrectableSwiftRule {
                     return nil
             }
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
-            let lineInsertions = [Line(lineNumber: insertLineNumber, codeString: "\n\(spacedMarkDescription)")]
+            let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
+            let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+            print(fileComponents[lineNumber - 1])
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/InitializationMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/InitializationMarkSectionSwiftRule.swift
@@ -61,7 +61,9 @@ final class InitializationMarkSectionSwiftRule: CorrectableSwiftRule {
                     return nil
             }
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
-            let lineInsertions = [Line(lineNumber: insertLineNumber, codeString: "\n\(spacedMarkDescription)")]
+            let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
+            let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+            
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/PrivatePropertyMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/PrivatePropertyMarkSectionSwiftRule.swift
@@ -61,7 +61,9 @@ final class PrivatePropertyMarkSectionSwiftRule: CorrectableSwiftRule {
                     return nil
             }
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
-            let lineInsertions = [Line(lineNumber: insertLineNumber, codeString: "\n\(spacedMarkDescription)")]
+            let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
+            let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+            
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/PublicFunctionMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/PublicFunctionMarkSectionSwiftRule.swift
@@ -62,7 +62,9 @@ final class PublicFunctionMarkSectionSwiftRule: CorrectableSwiftRule {
                     return nil
             }
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
-            let lineInsertions = [Line(lineNumber: insertLineNumber, codeString: "\n\(spacedMarkDescription)")]
+            let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
+            let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Rules/Documentation/Mark Section/PublicPropertyMarkSectionSwiftRule.swift
+++ b/Moulinette/Rules/Documentation/Mark Section/PublicPropertyMarkSectionSwiftRule.swift
@@ -61,7 +61,9 @@ final class PublicPropertyMarkSectionSwiftRule: CorrectableSwiftRule {
                 return nil
             }
             let insertLineNumber = fileComponents.aboveCommentLineNumber(violationLineNumber: lineNumber)
-            let lineInsertions = [Line(lineNumber: insertLineNumber, codeString: "\n\(spacedMarkDescription)")]
+            let codeString = "\(insertLineNumber.insertTopSpace ? "\n" : "")\(spacedMarkDescription)\n"
+            let lineInsertions = [Line(lineNumber: insertLineNumber.lineNumber, codeString: codeString)]
+
             return FileCorrection(fileName: violation.fileName,
                                   lineNumber: lineNumber,
                                   customString: nil,

--- a/Moulinette/Utility/Extensions/Array+LineNumber.swift
+++ b/Moulinette/Utility/Extensions/Array+LineNumber.swift
@@ -28,12 +28,8 @@ extension Array where Element == String {
             let formattedString = self[index].replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\n", with: "")
             if formattedString.isComment() {
                 continue
-            }
-
-            if formattedString.isEmpty {
-                return (index + 2, false)
             } else {
-                return (index + 2, true)
+                return (index + 2, !formattedString.isEmpty)
             }
         }
         return (0, false)

--- a/Moulinette/Utility/Extensions/Array+LineNumber.swift
+++ b/Moulinette/Utility/Extensions/Array+LineNumber.swift
@@ -17,10 +17,10 @@ extension Array where Element == String {
         return nil
     }
 
-    /// Returns the line number above comments.
+    /// Returns the line number above comments
     ///
-    /// - Parameter violationLineNumber: Line number violation.
-    /// - Returns: Updated line number where there is no comment.
+    /// - Parameter violationLineNumber: Line number violation
+    /// - Returns: The updated line number where there is no comment and whether an additional space should be added.
     func aboveCommentLineNumber(violationLineNumber: Int) -> (lineNumber: Int, insertTopSpace: Bool) {
         let startLineNumber = violationLineNumber-1
         let startIndex = startLineNumber-1

--- a/Moulinette/Utility/Extensions/Array+LineNumber.swift
+++ b/Moulinette/Utility/Extensions/Array+LineNumber.swift
@@ -21,14 +21,22 @@ extension Array where Element == String {
     ///
     /// - Parameter violationLineNumber: Line number violation.
     /// - Returns: Updated line number where there is no comment.
-    func aboveCommentLineNumber(violationLineNumber: Int) -> Int {
+    func aboveCommentLineNumber(violationLineNumber: Int) -> (lineNumber: Int, insertTopSpace: Bool) {
         let startLineNumber = violationLineNumber-1
-        for index in stride(from: startLineNumber-1, through: 0, by: -1) {
-            if !self[index].isComment() {
-                return (self[index] == "") ? index+1 : index+2
+        let startIndex = startLineNumber-1
+        for index in stride(from: startIndex, through: 0, by: -1) {
+            let formattedString = self[index].replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\n", with: "")
+            if formattedString.isComment() {
+                continue
+            }
+
+            if formattedString.isEmpty {
+                return (index + 2, false)
+            } else {
+                return (index + 2, true)
             }
         }
-        return 0
+        return (0, false)
     }
 
     func removeCommentEmptyStrings(lineNumber: Int) -> [Int] {

--- a/Moulinette/main.swift
+++ b/Moulinette/main.swift
@@ -26,7 +26,7 @@ let output = audit.runRules()
 audit.autoCorrect()
 
 if settings.debugMode {
-    print("############### MOULINETTE AUDITOR v0.1.3 ###############")
+    print("############### MOULINETTE AUDITOR v0.1.4 ###############")
     if settings.xcodePlugin {
         print(output.xcodeDescription())
     } else {


### PR DESCRIPTION
Some of the MARK comment spacing rules will autocorrect incorrectly

Expected: 
```
// MARK: - Initialization 

init() {
}
```

Actual: 
```
// MARK: - Initialization 
init() {
}
```